### PR TITLE
 fix ParseInt() bug in config file

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -37,7 +37,7 @@ if (!PRIVATE_KEY) {
 }
 
 // Set a specific bock number to fork (optional)
-const FORKING_BLOCK_NUMBER = process.env.FORKING_BLOCK_NUMBER ? parseInt(process.env.FORKING_BLOCK_NUMBER) : undefined
+const FORKING_BLOCK_NUMBER = isNaN(process.env.FORKING_BLOCK_NUMBER) ? undefined : parseInt(process.env.FORKING_BLOCK_NUMBER)
 
 // Your API key for Etherscan, obtain one at https://etherscan.io/ (optional)
 const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY || "Your etherscan API key"


### PR DESCRIPTION
parseInt() can return NaN if the env var is set to a string.

This returns error when evaluated in the ternary operator.

Updated logic to check if the env var is a number and if it is

this will evaluate to undefined since this is an optional setting.